### PR TITLE
Fixes support for templates if using WordPress 4.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,38 @@
 # MKS Data Catalogue
 
-The MKS Data Catalogue component is a plugin for the Wordpress content management system (https://wordpress.org/) which enhance it with data cataloguing capabilities, similar to popular data catalogue, registry or repository platforms. It creates a new type of posts for datasets and another one the licences (redistribution policies) associated with the datasets. It also include page templates for searching and browsing the data, as well as creating forms to register new basic datasets. 
+The MKS Data Catalogue component is a plugin for the WordPress content management system (https://wordpress.org/) which enhance it with data cataloguing capabilities, similar to popular data catalogue, registry or repository platforms. It creates a new type of posts for datasets and another one the licences (redistribution policies) associated with the datasets. It also include page templates for searching and browsing the data, as well as creating forms to register new basic datasets. 
 
-Amongst the advantages of the MKS Data Catalogue component is the very easy deployment (as long as you have a Wordpress platform installed, which is straighforward), as well as the ease of customisation and extension (by modifying the stylesheets and templates available, or creating wordpress plugins interacting with the catalogue).
+Amongst the advantages of the MKS Data Catalogue component is the very easy deployment (as long as you have a WordPress platform installed, which is straighforward), as well as the ease of customisation and extension (by modifying the stylesheets and templates available, or creating WordPress plugins interacting with the catalogue).
 
 ## Installation 
 
-You should have Wordpress running and configured before installing the MKS Data Cataloguing component. Once that's done, download or clone this repository and copy the "mks-data-cataloguing" repository in the "wp-content/plugin/" folder of your wordpress installation. The plugin will then appear in the plugin area of the Wordpress admin interface, and you should be able to activate it.
+Be sure to have:
+
+- an instance of [WordPress](https://wordpress.org/download/release-archive/) (we recommend versions 4.3-4.7.x) configured and running;
+- the [Composer](https://getcomposer.org/) PHP package manager.
+
+Install the MKS Data Cataloguing component:
+
+1. Clone this repository or download ZIP file and unpack it
+2. Install third-party dependencies: 
+2.1. Go to plugin directory: `$ cd mks-data-cataloguing`
+2.2. Run `$ php composer.phar install` or `$ composer install`, depending on how you installed Composer (see its documentation)
+3. Copy the `mks-data-cataloguing` directory to the `wp-content/plugins/` folder of your WordPress installation
+4. Open your WordPress admin dashboard on your Web Browser, select the __Plugins__ menu and activate the __MKS Data Cataloguing__ plugin.
 
 ## How to use
 
-Once activited, the MKS Data Cataloging plugin will create a new type of post called "Datasets" available from the right hand side menu of the Wordpress admin interface. This acts like a typical Wordpress post, which can be described using text, tags and categories. In addition, fields are added that are specific to datasets, including the data owner, format, status, and licences (redistribution policies).
+Once activited, the MKS Data Cataloging plugin will create a new type of post called "Datasets" available from the right hand side menu of the WordPress admin interface. This acts like a typical WordPress post, which can be described using text, tags and categories. In addition, fields are added that are specific to datasets, including the data owner, format, status, and licences (redistribution policies).
 
 Available licences (redistribution policies) can be edited through another type of post, which can include the text of the licence document, as well as a basic description of its clauses in terms of duties, permissions and prohibitions. 
 
 You can also point directly to the dataset by including it as a source file or link, and attach to the dataset a number of services that use or give access to the data in a specific way.
 
-The plugin will also create a number of page templates that can be used to create dedicated pages, including "Data Catalogue Public Page" (for searching and browsing datasets) and "New Dataset Page" (for a form to create a new dataset without using the Wordpress admin interface).
+The plugin will also create a number of page templates that can be used to create dedicated pages, including "Data Catalogue Public Page" (for searching and browsing datasets) and "New Dataset Page" (for a form to create a new dataset without using the WordPress admin interface).
 
 ## Licence and attribution
 
-Being a Wordpress plugin, MKS Data Cataloguing inherit the GPL licence from it. It is therefore available here under the GPL V3 licence (https://www.gnu.org/licenses/gpl-3.0.en.html). 
+Being a WordPress plugin, MKS Data Cataloguing inherit the GPL licence from it. It is therefore available here under the GPL V3 licence (https://www.gnu.org/licenses/gpl-3.0.en.html). 
 
 Whenever making a website that include the MKS Data Cataloguing function in a public way, please include in a visible place (e.g. you "About" page) a setence attributing the source of the plugin and linking back to this repository, e.g.
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Install the MKS Data Cataloguing component:
 
 1. Clone this repository or download ZIP file and unpack it
 2. Install third-party dependencies: 
-2.1. Go to plugin directory: `$ cd mks-data-cataloguing`
-2.2. Run `$ php composer.phar install` or `$ composer install`, depending on how you installed Composer (see its documentation)
+   + Go to plugin directory: `$ cd mks-data-cataloguing`
+   + Run `$ php composer.phar install` or `$ composer install`, depending on how you installed Composer (see its documentation)
 3. Copy the `mks-data-cataloguing` directory to the `wp-content/plugins/` folder of your WordPress installation
 4. Open your WordPress admin dashboard on your Web Browser, select the __Plugins__ menu and activate the __MKS Data Cataloguing__ plugin.
 

--- a/mks-data-cataloguing/.gitignore
+++ b/mks-data-cataloguing/.gitignore
@@ -1,3 +1,5 @@
 /.settings/
 /.buildpath
 /.project
+
+/vendor/

--- a/mks-data-cataloguing/inc/controller/data-catalogue.inc
+++ b/mks-data-cataloguing/inc/controller/data-catalogue.inc
@@ -1,4 +1,9 @@
-<?php 
+<?php
+/*
+ * Template Name: Data Catalogue Public Page
+ * Description: Template for pages used to list available datasets.
+ */
+
 require_once(dirname(__FILE__) . '/abstract-controller.inc');
 
 class MKSDC_DataCatalogue_Controller extends MKSDC_AbstractController{

--- a/mks-data-cataloguing/inc/html/data-catalogue-aside.phtml
+++ b/mks-data-cataloguing/inc/html/data-catalogue-aside.phtml
@@ -1,60 +1,35 @@
-<div class="col-lg-4 col-md-4 col-sm-4 col-xs-6">
-<aside id="aside" role="complementary">
-<h1>Categories</h1>			
-<div class="textwidget"><div class="check">
+<div class="col-sm-3 col-lg-2 taxonomy">
+  <aside id="aside" role="complementary">
+    <h1>Categories</h1>			
+    <div class="textwidget">
+      <div class="check">
 <?php
-	$args = $this->get('args',array('category__in'=> array()));
+	$args = $this->get( 'args', array('category__in'=> array()) );
 	$categories = get_categories(array(
-		'show_option_all'    => '',
-			'orderby'            => 'name',
-			'order'              => 'ASC',
-			'style'              => 'list',
-			'show_count'         => 1,
-			'hide_empty'         => 0,
-			'use_desc_for_title' => 1,
-			'child_of'           => 0,
-			'feed'               => '',
-			'feed_type'          => '',
-			'feed_image'         => '',
-			'exclude'            => '',
-			'exclude_tree'       => '',
-			'include'            => '',
-			'hierarchical'       => 1,
-			'title_li'           => __( 'Categories' ),
-			'show_option_none'   => __( 'No categories' ),
-			'number'             => null,
-			'echo'               => 1,
-			'depth'              => 0,
-			'current_category'   => 0,
-			'pad_counts'         => 0,
-			'taxonomy'           => 'category',
-			'walker'             => null
+		'hierarchical'     => TRUE,
+		'orderby'          => 'count',
+		'title_li'         => __( 'Categories' ),
+		'show_option_none' => __( 'No categories' ),
+		'taxonomy'         => 'category'
    	));
 ?>
+        <ul>
 <?php foreach($categories as $category): ?>
-<input
+          <li<?php if(!empty($category->category_parent)) print ' class="subcat"' ?>>
+          <input
 	<?php if(in_array($category->term_id, $args['category__in'])):?>
 	checked="checked"
 	<?php endif;?>
 	onchange="form.submit()"
-	name="cat[<?php
-						$cat = $category->term_id;
-						print $cat;
-						?>]"
-	id="cat[<?php print $cat; ?>]"
+	name="cat[<?php print $category->term_id ?>]"
+	id="cat[<?php print $category->term_id ?>]"
 	type="checkbox"
-	value="<?php print $cat; ?>" />
-	<label for="cat[<?php print $cat; ?>]">&nbsp;<?php print $category->name; ?></label>
+	value="<?php print $category->term_id ?>"/>
+	<label for="cat[<?php print $category->term_id; ?>]">&nbsp;<?php print $category->name; ?></label>
+	      </li>
 <?php endforeach; ?>
-<!--                             <input type="checkbox" value="0" id="educationCheck" name="education" /><label for="educationCheck">Education</label>
-                            <input type="checkbox" value="0" id="transportCheck" name="transport" /><label for="transportCheck">Transport</label>
-                            <input type="checkbox" value="0" id="energyCheck" name="energy" /><label for="energyCheck">Energy</label>
-                            <input type="checkbox" value="0" id="waterCheck" name="water" /><label for="waterCheck">Water</label>
-                            <input type="checkbox" value="0" id="businessCheck" name="business" /><label for="businessCheck">Business</label>
-                            <input type="checkbox" value="0" id="sensorsCheck" name="sensors" /><label for="sensorsCheck">Sensors</label>
-                            <input type="checkbox" value="0" id="statisticsCheck" name="statistics" /><label for="statisticsCheck">Statistics</label>
-                            <input type="checkbox" value="0" id="environmentCheck" name="environment" /><label for="environmentCheck">Environment</label>
--->                            
-</div></div>
-</aside>
+        </ul>
+      </div>
+    </div>
+  </aside>
 </div>

--- a/mks-data-cataloguing/inc/html/data-catalogue-results.phtml
+++ b/mks-data-cataloguing/inc/html/data-catalogue-results.phtml
@@ -1,5 +1,5 @@
 <?php $args = $this->get('args'); ?>
-<div class="col-lg-8 col-md-8 col-sm-8 col-xs-6">
+<div class="col-sm-9 col-lg-10 datasets">
 <section role="main">
 <article id="post-<?php print get_the_ID(); ?>" class="post-<?php print get_the_ID(); ?> page type-page status-publish hentry">
 <div class="alignright"></div>

--- a/mks-data-cataloguing/mks-data-cataloguing.php
+++ b/mks-data-cataloguing/mks-data-cataloguing.php
@@ -6,7 +6,7 @@
  Plugin Name: MKS Data Cataloguing
 Plugin URI: http://mksmart.org
 Description: To register datasets and the information related to their import and redistribution in the MK:Smart Datahub
-Version: 1.2-RC1 - 23-03-2016
+Version: 1.2-RC2 - 10-05-2017
 Author: enridaga, mdaquin
 Author URI: http://kmi.open.ac.uk/
 License: Apache 2.0
@@ -221,7 +221,16 @@ class MKSDC_Plugin{
 	private function _initPageTemplates(){
 		$this->_templates = array();
 		// Add a filter to the attributes metabox to inject template into the cache.
-		add_filter( 'page_attributes_dropdown_pages_args', array( $this, 'registerProjectTemplates' ) );
+		// add_filter( 'page_attributes_dropdown_pages_args', array( $this, 'registerProjectTemplates' ) );
+		if ( version_compare( floatval( get_bloginfo( 'version' ) ), '4.7', '<' ) ) {
+			// 4.6 and older
+			add_filter( 'page_attributes_dropdown_pages_args', 
+				array( $this, 'registerProjectTemplates' ) 
+			);
+		} else {
+			// 4.7+ : Add a filter to the wp 4.7 version attributes metabox
+			add_filter( 'theme_page_templates', array( $this, 'addNewTemplates' ) );
+		}
 		// Add a filter to the save post to inject out template into the page cache
 		add_filter( 'wp_insert_post_data', array( $this, 'registerProjectTemplates' ) );
 		// Add a filter to the template include to determine if the page has our
@@ -247,6 +256,15 @@ class MKSDC_Plugin{
 		$existing_mimes['ld'] = 'application/ld+json';
 		
 		return $existing_mimes;
+	}
+
+	/**
+	 * Adds our template to the page dropdown for v4.7+
+	 *
+	 */
+	public function addNewTemplates( $posts_templates ) {
+		$posts_templates = array_merge( $posts_templates, $this->_templates );
+		return $posts_templates;
 	}
 
 	/**


### PR DESCRIPTION
WordPress version 4.7 and above has changed the way page templates are registered. This code update now supports both the 4.7 method and the previous method.

There is also an update to the README file documenting that you need to install the dependencies with Composer (this was already a requirement in the plugin code but was not documented).

This commit also advances the version number to a new release candidate.